### PR TITLE
Implement setting vm hostname via environment variable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,6 +58,7 @@ Vagrant::Config.run do |config|
       local.vm.box = cfg[:box]
       local.vm.box_url = cfg[:box_url]
 #      local.vm.boot_mode = :gui
+      local.vm.host_name = ENV['VAGRANT_HOSTNAME'] || "localhost"
       local.vm.provision :puppet do |puppet|
         puppet.manifests_path = "manifests"
         puppet.module_path = "modules"

--- a/Vagrantfile.default
+++ b/Vagrantfile.default
@@ -58,6 +58,7 @@ Vagrant::Config.run do |config|
       local.vm.box = cfg[:box]
       local.vm.box_url = cfg[:box_url]
 #      local.vm.boot_mode = :gui
+      local.vm.host_name = ENV['VAGRANT_HOSTNAME'] || "localhost"
       local.vm.provision :puppet do |puppet|
         puppet.manifests_path = "manifests"
         puppet.module_path = "modules"


### PR DESCRIPTION
Allows me to use my puppet repository unchanged, with:

```
VAGRANT_HOSTNAME="puppet.node.name" vagrant up Scientific6_64
```
