### PR TITLE
Convert underscores in hostnames

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant::Config.run do |config|
       local.vm.box = cfg[:box]
       local.vm.box_url = cfg[:box_url]
 #      local.vm.boot_mode = :gui
-      local.vm.host_name = ENV['VAGRANT_HOSTNAME'] || name.to_s
+      local.vm.host_name = ENV['VAGRANT_HOSTNAME'] || name.to_s.gsub(/_/, "-")
       local.vm.provision :puppet do |puppet|
         puppet.manifests_path = "manifests"
         puppet.module_path = "modules"


### PR DESCRIPTION
Substitute underscores in names for hyphens when setting hostnames. These
aren't legally valid and some OSs, such as Debian 6, will outright refuse.

Keeping the names in the hash as underscores for compatbility with existing
users and so that they don't have to be modified from symbols.
